### PR TITLE
Reconfirm outstanding log security fixes on latest push

### DIFF
--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,0 +1,52 @@
+# Security Review Report
+
+## Overview
+This report summarizes the most critical security risks identified in the current codebase. Each issue includes an impact description, affected components, and recommended mitigations.
+
+## Top Issues
+
+1. **Default Administrative Credentials (High)**  
+   *Description*: The system auto-creates an `admin` user with the hardcoded password `admin123456` whenever no admin exists. Anyone with network access to the authentication endpoints can immediately take over the environment if the default password is not changed before deployment.  
+   *Evidence*: `initializeDefaultUser` seeds `admin@example.com` / `admin123456` and persists it to disk.【F:interface/backend/src/services/user-service.ts†L166-L190】  
+   *Recommendation*: Remove hardcoded credentials. Require explicit, secure admin bootstrap via environment variables or a one-time setup flow that enforces strong, unique passwords.
+
+2. **Predictable JWT Secret Fallback (High)**  
+   *Description*: When `JWT_SECRET` is unset, both token issuance and verification fall back to the public string `"your-secret-key"`. Attackers can mint valid tokens or forge refresh tokens, gaining full control of authenticated APIs.  
+   *Evidence*: `UserService` and `authenticateToken` both default to the same static secret when the environment variable is missing.【F:interface/backend/src/services/user-service.ts†L24-L33】【F:interface/backend/src/middleware/auth.ts†L16-L33】  
+   *Recommendation*: Fail fast if `JWT_SECRET` is absent. Enforce strong, random secrets in configuration and prevent the application from starting without them.
+
+3. **Server-Side Request Forgery in Prompt Import (High)**  
+   *Description*: `/api/import/url` fetches arbitrary URLs supplied by authenticated users without allow-listing or protocol restrictions. This enables SSRF to internal services (e.g., metadata endpoints, AWS instance metadata) and can exfiltrate sensitive data.  
+   *Evidence*: `importFromUrl` passes user-provided URLs directly to `fetch` after minimal validation.【F:interface/backend/src/controllers/import.ts†L112-L158】  
+   *Recommendation*: Restrict imports to trusted domains or signed sources, enforce protocol allow-lists, and add network-layer protections (e.g., SSRF proxy, URL validation with DNS/IP checks).
+
+4. **Log File Path Traversal (High)**  
+   *Description*: The log viewing API accepts a `filename` path segment and joins it directly with the logs directory. Attackers with the `system:config` permission can request `../../../../etc/passwd` (or similar) and read arbitrary files accessible to the process.  
+   *Evidence*: `getLogFileContent` forwards unsanitized filenames to `logReaderService.readLogFile`, which uses `path.join` without enforcing directory boundaries.【F:interface/backend/src/controllers/system.ts†L300-L333】【F:interface/backend/src/services/log-reader-service.ts†L83-L125】  
+   *Recommendation*: Normalize and validate filenames, reject path traversal sequences, and maintain an allow-list of known log files before reading from disk.
+
+5. **Unauthenticated Log Ingestion Enables Log Forgery / DoS (Medium)**  
+   *Description*: The `/api/v1/logs/frontend` and `/api/v1/logs/frontend/batch` endpoints allow anyone to submit arbitrary log messages that are written to server log files. An attacker can flood storage, obscure true audit events, or inject misleading log entries.  
+   *Evidence*: Log ingestion routes are exposed without authentication and forward request bodies straight into the logger.【F:interface/backend/src/routes/logs.ts†L7-L115】  
+   *Recommendation*: Require authentication and rate limiting for log ingestion, validate message content, and cap total log volume accepted from clients.
+
+## Remediation Priorities
+
+1. **Eliminate hardcoded admin credentials** – Block default account creation and enforce secure bootstrap procedures.
+2. **Enforce secure JWT configuration** – Require strong secrets and abort startup if `JWT_SECRET` is missing.
+3. **Harden URL import workflow** – Implement strict SSRF defenses (domain allow-listing, protocol filtering, and metadata IP blocking).
+4. **Sanitize log file access paths** – Validate filenames against an allow-list before file I/O to prevent traversal.
+5. **Protect log ingestion endpoints** – Add authentication, throttling, and input validation to prevent log abuse and storage exhaustion.
+
+## Verification of Remediations (Latest Release)
+
+The latest code pulled from the public Git repository (tagged as the most recent release at the time of this review) was re-examined specifically for the previously reported remediation items **4** and **5**. Both vulnerabilities are still present:
+
+* **Log file path traversal remains exploitable** – `readLogFile` continues to join user input directly into a filesystem path without canonicalization or directory boundary checks, so a crafted `../../` filename can escape the logs directory.【F:interface/backend/src/services/log-reader-service.ts†L90-L145】
+* **Log ingestion endpoints are still unauthenticated** – `/api/v1/logs/frontend` and `/api/v1/logs/frontend/batch` still accept arbitrary requests and write untrusted content to the server logs with no authentication, rate limiting, or origin validation.【F:interface/backend/src/routes/logs.ts†L7-L132】
+
+### Follow-up Verification (Latest Push `56d3939b7d81`)
+
+After pulling the most recent push from Git (`56d3939b7d81`), no code changes were introduced that mitigate issues **4** or **5**. The `LogReaderService` still constructs file paths by joining attacker-controlled filenames with the logs directory, enabling traversal outside of the intended folder, and the frontend log ingestion routes remain mounted without any authentication middleware. As a result, both vulnerabilities persist exactly as previously documented.【F:interface/backend/src/services/log-reader-service.ts†L90-L145】【F:interface/backend/src/routes/logs.ts†L7-L132】
+
+Addressing these items in priority order will significantly reduce the risk of compromise or misuse when the application is deployed.


### PR DESCRIPTION
## Summary
- add a follow-up verification section confirming that the latest git push (56d3939b7d81) still exhibits the path traversal and unauthenticated log ingestion issues
- refresh evidence citations to the current backend log reader and log ingestion implementations

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e6785e804c832d91d7630ab0bfe9ed